### PR TITLE
Issue 6 - Modifying the settings object 

### DIFF
--- a/examples/complete/seed.manifest.json
+++ b/examples/complete/seed.manifest.json
@@ -64,7 +64,6 @@
 				"settings": [
 					{
 						"name": "SETTING1",
-						"value": "5432"
 					}
 				]
 			},

--- a/examples/complete/seed.manifest.json
+++ b/examples/complete/seed.manifest.json
@@ -64,6 +64,7 @@
 				"settings": [
 					{
 						"name": "SETTING1",
+						"secret": false
 					}
 				]
 			},

--- a/schema/seed.manifest.schema.json
+++ b/schema/seed.manifest.schema.json
@@ -217,13 +217,9 @@
 										"name": {
 											"type": "string"
 										},
-										"value": {
-											"type": "string"
-										}
 									},
 									"required": [
-										"name",
-										"value"
+										"name"
 									]
 								}
 							}

--- a/schema/seed.manifest.schema.json
+++ b/schema/seed.manifest.schema.json
@@ -217,6 +217,10 @@
 										"name": {
 											"type": "string"
 										},
+										"secret": {
+											"type": "boolean",
+											"default": false
+										},
 									},
 									"required": [
 										"name"

--- a/sections/standard.adoc
+++ b/sections/standard.adoc
@@ -289,10 +289,8 @@ member key that differs from the value of `name` member.
 The Settings object is the member responsible for indicating all content not related to data that is needed for the
 Job to run.
 
-* The Settings object MUST have a member `name`. The member's value is a string that correlates to referenced setting
-injections elsewhere in the Interface.
-* The Settings object MUST have a member `value`. The member's value is a string that indicates the desired value to
-associate with the setting object.
+* The Settings object MUST have a member `name`. The member's value is a string that correlates setting references
+ elsewhere in the Interface to an external settings repository, and guides the injection of a related value.
 
 The following annotated snippet provides quick reference to the use of the Settings object:
 
@@ -300,11 +298,9 @@ The following annotated snippet provides quick reference to the use of the Setti
 ----
 {
   "name": "SETTING1", // <1>
-  "value": "5432" // <2>
 }
 ----
 <1> Required string containing the name to be used to lookup uses in the Interface.
-<2> Required string indicating the value to associate with the setting name.
 
 [[envvars-section, EnvVars Object]]
 ====== EnvVars Object

--- a/sections/standard.adoc
+++ b/sections/standard.adoc
@@ -300,7 +300,7 @@ The following annotated snippet provides quick reference to the use of the Setti
 ----
 {
   "name": "SETTING1", // <1>
-  "secret": true, // <1>
+  "secret": true, // <2>
 }
 ----
 <1> Required string containing the name to be used to lookup uses in the Interface.

--- a/sections/standard.adoc
+++ b/sections/standard.adoc
@@ -291,6 +291,8 @@ Job to run.
 
 * The Settings object MUST have a member `name`. The member's value is a string that correlates setting references
  elsewhere in the Interface to an external settings repository, and guides the injection of a related value.
+* The Settings object MAY have a member `secret`. The member's value is a boolean that indicates whether the value
+ associated with the named setting is secret and stored as a secure string.
 
 The following annotated snippet provides quick reference to the use of the Settings object:
 
@@ -298,9 +300,11 @@ The following annotated snippet provides quick reference to the use of the Setti
 ----
 {
   "name": "SETTING1", // <1>
+  "secret": true, // <1>
 }
 ----
 <1> Required string containing the name to be used to lookup uses in the Interface.
+<2> Optional boolean indicating whether the setting value is sensitive and stored as a secret.
 
 [[envvars-section, EnvVars Object]]
 ====== EnvVars Object


### PR DESCRIPTION
Jonathan - 

- Removed references to the `value` tag under the settings object as the Dockerfile shouldn't contain any actual settings values.  The name will be used to correlate to a database and replace the other instances of that same name throughout the definition.  
- Added a `secret` flag for settings to indicate if that value is in Vault. 

- Do you think we need a `required` flag for settings?  I thought we talked about this and determined that if it isn't required it won;'t be in the interface when someone defines it.  If you want that in there I can add it.  