### PR TITLE
Access validation and Docker version checking

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -78,12 +78,6 @@ func main() {
 	// Parse input flags
 	DefineFlags()
 
-	// seed list: Lists all seed compliant images on (default) local machine
-	if listCmd.Parsed() {
-		DockerList()
-		os.Exit(0)
-	}
-
 	// seed validate: Validate seed.manifest.json.
 	if validateCmd.Parsed() {
 		seedFileName := SeedFileName()
@@ -97,6 +91,15 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s", err.Error())
 		}
+		os.Exit(0)
+	}
+
+	// Checks if Docker requires sudo access. Prints error message if so.
+	CheckSudo()
+
+	// seed list: Lists all seed compliant images on (default) local machine
+	if listCmd.Parsed() {
+		DockerList()
 		os.Exit(0)
 	}
 
@@ -169,8 +172,11 @@ func DockerBuild(imageName string) {
 
 	// Build Docker image
 	fmt.Fprintf(os.Stderr, "INFO: Building %s\n", imageName)
-	buildCmd := exec.Command("docker", "build", "-t", imageName, jobDirectory,
-		"--label", label)
+	buildArgs := []string{"build", "-t", imageName, jobDirectory}
+	if DockerVersionHasLabel() {
+		buildArgs = append(buildArgs, "--label", label)
+	}
+	buildCmd := exec.Command("docker", buildArgs...)
 
 	// attach stderr pipe
 	errPipe, err := buildCmd.StderrPipe()
@@ -474,11 +480,14 @@ func DockerRun() {
 		}
 	}
 
-	// mount the OUTPUT_DIR (outDir flag)
-	outDir := SetOutputDir(imageName, &seed)
-	if outDir != "" {
-		mountsArgs = append(mountsArgs, "-v")
-		mountsArgs = append(mountsArgs, outDir+":"+outDir)
+	// mount the JOB_OUTPUT_DIR (outDir flag)
+	var outDir string
+	if strings.Contains(seed.Job.Interface.Cmd, "OUTPUT_DIR") {
+		outDir = SetOutputDir(imageName, &seed)
+		if outDir != "" {
+			mountsArgs = append(mountsArgs, "-v")
+			mountsArgs = append(mountsArgs, outDir+":"+outDir)
+		}
 	}
 
 	// Settings
@@ -947,7 +956,7 @@ func SetOutputDir(imageName string, seed *objects.Seed) string {
 	//	auto create a time-stamped subdirectory with the name of the form:
 	//		imagename-iso8601timestamp
 	if outputDir == "" {
-		outputDir = imageName + "-" + time.Now().Format(time.RFC3339)
+		outputDir = "output-" + imageName + "-" + time.Now().Format(time.RFC3339)
 		outputDir = strings.Replace(outputDir, ":", "_", -1)
 	}
 
@@ -1312,4 +1321,83 @@ func GetFullPath(rFile string) string {
 	}
 
 	return rFile
+}
+
+//CheckSudo Checks error for telltale sign seed command should be run as sudo
+func CheckSudo() {
+	cmd := exec.Command("docker", "info")
+
+	// attach stderr pipe
+	errPipe, err := cmd.StderrPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Error attaching to version command stderr. %s\n", err.Error())
+	}
+
+	// Run docker build
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Error executing docker version. %s\n",
+			err.Error())
+	}
+
+	slurperr, _ := ioutil.ReadAll(errPipe)
+	er := string(slurperr)
+	if er != "" {
+		if strings.Contains(er, "Cannot connect to the Docker daemon. Is the docker daemon running on this host?") ||
+			strings.Contains(er, "dial unix /var/run/docker.sock: connect: permission deied") {
+			fmt.Fprintf(os.Stderr, "Elevated permissions are required by seed to run Docker. Try running the seed command again as sudo.\n")
+		}
+		os.Exit(1)
+	}
+}
+
+//DockerVersionHasLabel returns if the docker version is greater than 1.11.1
+func DockerVersionHasLabel() bool {
+	cmd := exec.Command("docker", "--version")
+
+	// Attach stdout pipe
+	outPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Error attaching to version command stdout. %s\n", err.Error())
+	}
+
+	// Run docker version
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Error executing docker version. %s\n",
+			err.Error())
+	}
+
+	// Print out any std out
+	slurp, _ := ioutil.ReadAll(outPipe)
+	if string(slurp) != "" {
+		// Trim extra text
+		versionStr := strings.TrimPrefix(string(slurp), "Docker version ")
+		versionStr = versionStr[0:strings.Index(versionStr, "-")]
+		version := strings.Split(versionStr, ".")
+
+		// check each part of version. Return false if 1st < 1, 2nd < 11, 3rd < 1
+		if len(version) > 1 {
+			v1, _ := strconv.Atoi(version[0])
+			v2, _ := strconv.Atoi(version[1])
+
+			// check for minimum of 1.11.1
+			if v1 == 1 {
+				if v2 > 11 {
+					return true
+				} else if v2 == 11 && len(version) == 3 {
+					v3, _ := strconv.Atoi(version[2])
+					if v3 >= 1 {
+						return true
+					}
+				}
+			} else if v1 > 1 {
+				return true
+			}
+
+			return false
+		}
+	}
+
+	return false
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -317,7 +317,7 @@ func SeedFromImageLabel(imageName string) objects.Seed {
 	seedStr = strings.Replace(seedStr, "\\/", "/", -1)
 	seedStr = strings.TrimSpace(seedStr)
 	seedStr = strings.TrimSuffix(strings.TrimPrefix(seedStr, "'\""), "\"'")
-	
+
 	seed := &objects.Seed{}
 
 	err = json.Unmarshal([]byte(seedStr), &seed)
@@ -1176,7 +1176,7 @@ func ValidateOutput(seed *objects.Seed, outDir string) {
 				constants.ResultsFileManifestName, err.Error())
 			return
 		}
-		
+
 		documentLoader := gojsonschema.NewStringLoader(string(bites))
 		_, err = documentLoader.LoadJSON()
 		if err != nil {
@@ -1184,7 +1184,7 @@ func ValidateOutput(seed *objects.Seed, outDir string) {
 				constants.ResultsFileManifestName, err.Error())
 			return
 		}
-		
+
 		schemaFmt := "{ \"type\": \"object\", \"properties\": { %s }, \"required\": [ %s ] }"
 		schema := ""
 		required := ""
@@ -1209,9 +1209,9 @@ func ValidateOutput(seed *objects.Seed, outDir string) {
 		if len(required) > 0 {
 			required = required[:len(required)-1]
 		}
-		
+
 		schema = fmt.Sprintf(schemaFmt, schema, required)
-		
+
 		schemaLoader := gojsonschema.NewStringLoader(schema)
 		schemaResult, err := gojsonschema.Validate(schemaLoader, documentLoader)
 		if err != nil {
@@ -1219,7 +1219,7 @@ func ValidateOutput(seed *objects.Seed, outDir string) {
 				err.Error())
 			return
 		}
-		
+
 		if len(schemaResult.Errors()) == 0 {
 			fmt.Fprintf(os.Stderr, "SUCCESS: Results manifest file is valid.\n")
 		}
@@ -1344,7 +1344,7 @@ func CheckSudo() {
 	er := string(slurperr)
 	if er != "" {
 		if strings.Contains(er, "Cannot connect to the Docker daemon. Is the docker daemon running on this host?") ||
-			strings.Contains(er, "dial unix /var/run/docker.sock: connect: permission deied") {
+			strings.Contains(er, "dial unix /var/run/docker.sock: connect: permission denied") {
 			fmt.Fprintf(os.Stderr, "Elevated permissions are required by seed to run Docker. Try running the seed command again as sudo.\n")
 			os.Exit(1)
 		}

--- a/cli/main.go
+++ b/cli/main.go
@@ -1346,8 +1346,8 @@ func CheckSudo() {
 		if strings.Contains(er, "Cannot connect to the Docker daemon. Is the docker daemon running on this host?") ||
 			strings.Contains(er, "dial unix /var/run/docker.sock: connect: permission deied") {
 			fmt.Fprintf(os.Stderr, "Elevated permissions are required by seed to run Docker. Try running the seed command again as sudo.\n")
+			os.Exit(1)
 		}
-		os.Exit(1)
 	}
 }
 

--- a/cli/objects/Seed.go
+++ b/cli/objects/Seed.go
@@ -22,7 +22,7 @@ type Seed struct {
 					MediaType string `json:"mediaType"`
 					Pattern   string `json:"pattern"`
 					Count     string `json:"count"`
-					Required  bool   `json:"required,string"`
+					Required  bool   `json:"required"`
 				}
 				JSON []struct {
 					Name     string `json:"name"`
@@ -41,7 +41,7 @@ type Seed struct {
 				Secret bool   `json:"secret"`
 			}
 			ErrorMapping []struct {
-				Code        int    `json:"code,string"`
+				Code        int    `json:"code"`
 				Title       string `json:"title"`
 				Description string `json:"description"`
 				Category    string `json:"category"`

--- a/spec/examples/addition-algorithm/seed.manifest.json
+++ b/spec/examples/addition-algorithm/seed.manifest.json
@@ -8,15 +8,10 @@
     "description": "Adds numbers together",
     "authorName": "Emily Smith",
     "timeout": 10,
+    "cpus": 0.1,
+    "mem": 1.0,
     "interface": {
       "cmd": "${INPUT_FILE} ${OUTPUT_DIR}",
-      "resources": {
-        "scalar": [
-          { "name": "cpu", "value": 0.1 },
-          { "name": "mem", "value": 1.0 },
-          { "name": "disk", "value": 1.0, "inputMultiplier": 1.0 }
-        ]
-      },
       "inputData": {
         "files": [
           {
@@ -34,7 +29,8 @@
             "name": "OUTPUT_FILE",
             "mediaType": "text/plain",
             "pattern": "*_output.txt",
-            "count": "4"
+            "count": "4",
+            "required": true
           }
         ],
         "json": [
@@ -63,6 +59,16 @@
           "name": "MOUNT2",
           "path": "/tmp/",
           "mode": "rw"
+        }
+      ],
+      "settings": [
+        {
+          "name": "SETTING1",
+          "secret": false
+        },
+        {
+          "name": "SETTING2",
+          "secret": true
         }
       ]
     },

--- a/spec/examples/addition-algorithm/seed.manifest.json
+++ b/spec/examples/addition-algorithm/seed.manifest.json
@@ -8,10 +8,15 @@
     "description": "Adds numbers together",
     "authorName": "Emily Smith",
     "timeout": 10,
-    "cpus": 0.1,
-    "mem": 1.0,
     "interface": {
       "cmd": "${INPUT_FILE} ${OUTPUT_DIR}",
+      "resources": {
+        "scalar": [
+          { "name": "cpu", "value": 0.1 },
+          { "name": "mem", "value": 1.0 },
+          { "name": "disk", "value": 1.0, "inputMultiplier": 1.0 }
+        ]
+      },
       "inputData": {
         "files": [
           {


### PR DESCRIPTION
#38 Handles checking access: Performs a `docker info` to validate user has proper permissions informs user if sudo may be needed to run. If connection issues ("Cannot connect to the Docker daemon...." or "... connect: permission denied" messages) detected, seed will print "Elevated permissions are required by seed to run Docker. Try running the seed command again as sudo." and terminate the program.
#44 Verifies the docker installation is version 1.11.1 or above before adding seed manifest label to image. Does not add the label if version is below 1.11.1
Fixed the Seed struct: 'settings.secret' is a bool instead of string.
 