### PR TITLE
Name addition for errors and overall consistency

### DIFF
--- a/spec/examples/complete/seed.manifest.json
+++ b/spec/examples/complete/seed.manifest.json
@@ -107,12 +107,14 @@
     "errors": [
       {
         "code": 1,
+        "name": "error-name-one",
         "title": "Error Name",
         "description": "Error Description",
         "category": "data"
       },
       {
         "code": 2,
+        "name": "error-name-two",
         "title": "Error Name",
         "description": "Error Description",
         "category": "job"

--- a/spec/examples/watermark/seed.manifest.json
+++ b/spec/examples/watermark/seed.manifest.json
@@ -38,9 +38,13 @@
     "errors": [
       {
         "code": 1,
-        "title": "Image Corrupt",
+        "name": "image-Corrupt",
         "description": "Image input is not recognized as a valid PNG.",
         "category": "data"
+      },
+      {
+        "code": 2,
+        "name": "algorithm-failure"
       }
     ]
   }

--- a/spec/schema/seed.manifest.schema.json
+++ b/spec/schema/seed.manifest.schema.json
@@ -13,7 +13,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "^[a-zA-Z0-9-]+$"
+          "pattern": "^[a-zA-Z-]+$"
         },
         "jobVersion": {
           "type": "string",

--- a/spec/schema/seed.manifest.schema.json
+++ b/spec/schema/seed.manifest.schema.json
@@ -13,7 +13,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "pattern": "^[a-z0-9_-]+$"
+          "pattern": "^[a-zA-Z0-9-]+$"
         },
         "jobVersion": {
           "type": "string",
@@ -304,6 +304,10 @@
               "code": {
                 "type": "integer"
               },
+              "name": {
+                "type": "string",
+                "pattern": "^[a-zA-Z_-]+$"
+              },
               "title": {
                 "type": "string"
               },
@@ -321,7 +325,7 @@
             },
             "required": [
               "code",
-              "title"
+              "name"
             ]
           }
         }

--- a/spec/sections/standard.adoc
+++ b/spec/sections/standard.adoc
@@ -48,8 +48,7 @@ The Job object is the core member for describing a single unit of work and the r
 
 |`name`
 |Required
-2+|MUST be a string of only lowercase alpha-numeric, dash or underscore characters (defined by the
-regex† `^[a-z0-9_-]+$`).
+2+|MUST be a string of only alpha-numeric or dash characters (defined by the regex† `^[a-zA-Z0-9-]+$`).
 
 |`jobVersion`
 |Required
@@ -112,8 +111,7 @@ without it resources provided will be default for the implementing framework.
 }
 ----
 a|
-<1> Required string containing job identifier. Limited to regex† `^[a-z0-9_-]+$`. `name` and `jobVersion` members
-combined should be unique system-wide.
+<1> Required string containing job identifier. `name` and `jobVersion` members combined should be unique system-wide.
 <2> Required string containing version identifier of job in SemVer format. `name` and `jobVersion` members
 combined should be unique system-wide.
 <3> Required string containing packaging version identifier in SemVer format. `packageVersion` is used to indicate
@@ -684,8 +682,8 @@ in passing information to the executor† to differentiate between data and job 
 
 |`name`
 |Required
-2+|MUST be a string of only lowercase alpha-numeric, dash or underscore characters (defined by the
-regex† `^[a-z0-9_-]+$`) indicating the unique name to use for referring to this error.
+2+|MUST be a string of only alphabetic, dash or underscore characters (defined by the regex† `^[a-zA-Z_-]+$`) 
+indicating the unique name to use for referring to this error.
 
 |`title`
 |Optional

--- a/spec/sections/standard.adoc
+++ b/spec/sections/standard.adoc
@@ -682,8 +682,13 @@ in passing information to the executor† to differentiate between data and job 
 |Required
 2+|MUST be an integer indicating the exit code of the executing job process.
 
-|`title`
+|`name`
 |Required
+2+|MUST be a string of only lowercase alpha-numeric, dash or underscore characters (defined by the
+regex† `^[a-z0-9_-]+$`) indicating the unique name to use for referring to this error.
+
+|`title`
+|Optional
 2+|MUST be a string indicating the short descriptive title of the error.
 
 |`description`
@@ -703,17 +708,19 @@ value is `job`.
 [
     {
         "code": 1, // <1>
-        "title": "Error Name", // <2>
-        "description": "Error Description", // <3>
-        "category": "job" // <4>
+        "name": "error-name", // <2>
+        "title": "Error Name", // <3>
+        "description": "Error Description", // <4>
+        "category": "job" // <5>
     },
     ...
 ]
 ----
 a|
 <1> Required integer indicating job process exit code.
-<2> Required string containing human-friendly short name of error.
-<3> Optional string containing complete error code description.
-<4> Optional string containing the error type. This value MUST be either: `job` or `data`. The default
+<2> Required string containing machine-friendly identifier of error.
+<3> Optional string containing human-friendly short name of error.
+<4> Optional string containing complete error code description.
+<5> Optional string containing the error type. This value MUST be either: `job` or `data`. The default
 value is `job`.
 |=====

--- a/spec/sections/standard.adoc
+++ b/spec/sections/standard.adoc
@@ -683,7 +683,8 @@ in passing information to the executor† to differentiate between data and job 
 |`name`
 |Required
 2+|MUST be a string of only alphabetic, dash or underscore characters (defined by the regex† `^[a-zA-Z_-]+$`) 
-indicating the unique name to use for referring to this error.
+indicating the unique name to use for referring to this error. An executor† MAY use member for correlation
+of error codes across job versions.
 
 |`title`
 |Optional

--- a/spec/sections/standard.adoc
+++ b/spec/sections/standard.adoc
@@ -48,7 +48,7 @@ The Job object is the core member for describing a single unit of work and the r
 
 |`name`
 |Required
-2+|MUST be a string of only alpha-numeric or dash characters (defined by the regex† `^[a-zA-Z0-9-]+$`).
+2+|MUST be a string of only alphabetic or dash characters (defined by the regex† `^[a-zA-Z-]+$`).
 
 |`jobVersion`
 |Required


### PR DESCRIPTION
- #115: Updated regex patterns on `name` members to be consistently `^[a-zA-Z_-]+$` except for `job.name` which does not allow `_` for clarity as it will be used in URLs.
- #114: Added `name` member to `job.errors` object.