### PR TITLE
Fixed code callouts in PDF generation

### DIFF
--- a/spec/styles/pdf-theme.yml
+++ b/spec/styles/pdf-theme.yml
@@ -21,6 +21,11 @@ font:
       bold_italic: mplus1p-regular-fallback.ttf
     Inconsolata:
       normal: Inconsolata-Regular.ttf
+    Inconsolata Fallback:
+      normal: mplus1mn-regular-ascii-conums.ttf
+      bold: mplus1mn-bold-ascii.ttf
+      italic: mplus1mn-italic-ascii.ttf
+      bold_italic: mplus1mn-bold_italic-ascii.ttf
     Dosis:
       normal: Dosis-Regular.ttf
       bold: Dosis-Bold.ttf
@@ -33,6 +38,7 @@ font:
       bold_italic: Roboto-BoldItalic.ttf
   fallbacks:
     - M+ 1p Fallback
+    - Inconsolata Fallback
 page:
   background_color: ffffff
   layout: portrait


### PR DESCRIPTION
#133 Added a fallback for the Inconsolata font to include the callout numbers so they are rendered properly in code blocks.